### PR TITLE
add Apex setting for approval lock/unlock and add Settings to manifest

### DIFF
--- a/force-app/main/default/settings/Apex.settings-meta.xml
+++ b/force-app/main/default/settings/Apex.settings-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <enableAggregateCodeCoverageOnly>false</enableAggregateCodeCoverageOnly>
+    <enableApexAccessRightsPref>false</enableApexAccessRightsPref>
+    <enableApexApprovalLockUnlock>true</enableApexApprovalLockUnlock>
+    <enableApexCtrlImplicitWithSharingPref>false</enableApexCtrlImplicitWithSharingPref>
+    <enableApexPropertyGetterPref>false</enableApexPropertyGetterPref>
+    <enableAuraApexCtrlAuthUserAccessCheckPref>false</enableAuraApexCtrlAuthUserAccessCheckPref>
+    <enableAuraApexCtrlGuestUserAccessCheckPref>true</enableAuraApexCtrlGuestUserAccessCheckPref>
+    <enableCompileOnDeploy>false</enableCompileOnDeploy>
+    <enableDisableParallelApexTesting>false</enableDisableParallelApexTesting>
+    <enableDoNotEmailDebugLog>false</enableDoNotEmailDebugLog>
+    <enableGaplessTestAutoNum>true</enableGaplessTestAutoNum>
+    <enableMngdCtrlActionAccessPref>false</enableMngdCtrlActionAccessPref>
+    <enableNonCertifiedApexMdCrud>false</enableNonCertifiedApexMdCrud>
+    <enableSecureNoArgConstructorPref>false</enableSecureNoArgConstructorPref>
+</ApexSettings>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -107,6 +107,12 @@
         <name>HomePageLayout</name>
     </types>
     <types>
+        <members>Apex</members>
+        <members>Security</members>
+        <members>BusinessHours</members>
+        <name>Settings</name>
+    </types>
+    <types>
         <members>Account-Account Layout</members>
         <members>Case-Case Layout</members>
         <members>CaseClose-Close Case Layout</members>


### PR DESCRIPTION
- ApexApprovalLockUnlock: Needed for approval process to run correctly
- Settings: Apex, BusinessHours, and Security are needed to pull the
security settings we configured on Kevin's org